### PR TITLE
Updates feature for upcoming submission deadline

### DIFF
--- a/timeline/index.markdown
+++ b/timeline/index.markdown
@@ -2,7 +2,7 @@
 title: Timeline
 category: For Authors
 order: 500
-featured: "Upcoming Submission Deadline: February 1, 2022"
+featured: "Upcoming Submission Deadline: June 1, 2022"
 ---
 Papers can be [submitted to the journal at any time](/submission/), but submitted papers are batched and reviewed in cycles with strict deadlines. The batch processing is designed to keep everyone involved (editors, reviewers and authors) on track, and to establish a strong sense of predictability for when specific activities are to happen. The goal is to have a fast turnaround of about **four months** from start to end of each reviewing cycle.
 


### PR DESCRIPTION
Not sure whether this is necessary, or whether we remove the feature until some time before the next deadline.